### PR TITLE
refactor: Agregar JWT a la logica de login. Closes #148

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ src/web/*.tsbuildinfo
 src/web/next-env.d.ts
 src/web/.env.local
 
-src/main/resources/application.properties
 bun.lock
 bun.lockb
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,26 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/skillstack/devhub/config/SecurityConfig.java
+++ b/src/main/java/com/skillstack/devhub/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.skillstack.devhub.config;
 
 
+import com.skillstack.devhub.security.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -11,6 +12,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -28,20 +30,15 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthenticationFilter jwtAuthFilter) throws Exception {
         http
                 .cors(Customizer.withDefaults())
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(HttpMethod.OPTIONS).permitAll()
-                        .requestMatchers(HttpMethod.GET).permitAll()
-                        .requestMatchers(HttpMethod.DELETE).permitAll()
-                        .requestMatchers(HttpMethod.POST).permitAll()
-                        .requestMatchers(HttpMethod.PUT).permitAll()
-
+                        .requestMatchers("/usuario/**").permitAll()   // login, register
                         .anyRequest().authenticated()
-                );
+                )
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/skillstack/devhub/controller/UserController.java
+++ b/src/main/java/com/skillstack/devhub/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.skillstack.devhub.controller;
 
 
+import com.skillstack.devhub.dto.LoginResponseDTO;
 import com.skillstack.devhub.dto.UserLoginDTO;
 import com.skillstack.devhub.dto.UserRegisterDTO;
 import com.skillstack.devhub.service.UserService;
@@ -33,9 +34,8 @@ public class UserController {
        
     }
 
-    @PostMapping ("/login")
-    public ResponseEntity<String> loginUser(@Valid @RequestBody UserLoginDTO request){
-            String respuesta = userService.login(request);
-            return ResponseEntity.ok(respuesta);
+    @PostMapping("/login")
+    public LoginResponseDTO login(@RequestBody UserLoginDTO request) {
+        return userService.login(request);
     }
 }

--- a/src/main/java/com/skillstack/devhub/dto/LoginResponseDTO.java
+++ b/src/main/java/com/skillstack/devhub/dto/LoginResponseDTO.java
@@ -1,0 +1,14 @@
+package com.skillstack.devhub.dto;
+
+import com.skillstack.devhub.model.Role;
+
+public class LoginResponseDTO {
+
+    private String token;
+    private String email;
+
+    public LoginResponseDTO(String token, String email) {
+        this.token = token;
+        this.email = email;
+    }
+}

--- a/src/main/java/com/skillstack/devhub/security/CustomUserDetailsService.java
+++ b/src/main/java/com/skillstack/devhub/security/CustomUserDetailsService.java
@@ -1,0 +1,39 @@
+package com.skillstack.devhub.security;
+
+import com.skillstack.devhub.model.Role;
+import com.skillstack.devhub.model.User;
+import com.skillstack.devhub.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Autowired
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+
+
+
+    @Override
+    public UserDetails loadUserByUsername(String email) {
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
+
+        SimpleGrantedAuthority authority = new SimpleGrantedAuthority("ROLE_" + user.getRol().name());
+
+        return org.springframework.security.core.userdetails.User
+                .withUsername(user.getEmail())
+                .password(user.getContrasena())
+                .authorities(authority)
+                .build();
+    }
+}

--- a/src/main/java/com/skillstack/devhub/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/skillstack/devhub/security/JwtAuthenticationFilter.java
@@ -1,0 +1,59 @@
+package com.skillstack.devhub.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final CustomUserDetailsService userDetailsService;
+
+
+    @Autowired
+    public JwtAuthenticationFilter(JwtUtil jwtUtil, CustomUserDetailsService userDetailsService) {
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+    }
+
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String header = request.getHeader("Authorization");
+
+        if (header == null || !header.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = header.substring(7);
+        String email = jwtUtil.extractEmail(token);
+
+        UserDetails userDetails =
+                userDetailsService.loadUserByUsername(email);
+
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities()
+                );
+
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/skillstack/devhub/security/JwtUtil.java
+++ b/src/main/java/com/skillstack/devhub/security/JwtUtil.java
@@ -1,0 +1,35 @@
+package com.skillstack.devhub.security;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    private final String SECRET;
+
+    public JwtUtil(@Value("${jwt.secret}") String secret) {
+        this.SECRET = secret;
+    }
+
+    public String generateToken(String email) {
+        return Jwts.builder()
+                .setSubject(email)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60))
+                .signWith(SignatureAlgorithm.HS256, SECRET)
+                .compact();
+    }
+
+    public String extractEmail(String token) {
+        return Jwts.parser()
+                .setSigningKey(SECRET)
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+}

--- a/src/main/java/com/skillstack/devhub/service/UserService.java
+++ b/src/main/java/com/skillstack/devhub/service/UserService.java
@@ -1,10 +1,12 @@
 package com.skillstack.devhub.service;
 
+import com.skillstack.devhub.dto.LoginResponseDTO;
 import com.skillstack.devhub.dto.UserLoginDTO;
 import com.skillstack.devhub.dto.UserRegisterDTO;
 import com.skillstack.devhub.model.Role;
 import com.skillstack.devhub.model.User;
 import com.skillstack.devhub.repository.UserRepository;
+import com.skillstack.devhub.security.JwtUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -16,11 +18,13 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
 
     @Autowired
-    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder, JwtUtil jwtUtil) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
+        this.jwtUtil = jwtUtil;
     }
 
     public String validarContrasena(String password){
@@ -74,22 +78,18 @@ public class UserService {
         userRepository.save(u);
     }
 
+    public LoginResponseDTO login(UserLoginDTO request) {
 
-    public String login(UserLoginDTO request){
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
 
-        User u = userRepository.findByEmail(request.getEmail())
-                .orElseThrow( ()->
-                        new ResponseStatusException(HttpStatus.UNAUTHORIZED,
-                                "Usuario o contraseña incorrectas"
-                        ));
-
-        if (!passwordEncoder.matches(request.getPassword(), u.getContrasena())) {
-            throw  new ResponseStatusException(HttpStatus.UNAUTHORIZED,
-                    "Usuario o contraseña incorrectas"
-            );
+        if (!passwordEncoder.matches(request.getPassword(), user.getContrasena())) {
+            throw new RuntimeException("Contraseña incorrecta");
         }
 
-        return "Login Exitoso";
+        String token = jwtUtil.generateToken(user.getEmail());
+
+        return new LoginResponseDTO(token, user.getEmail());
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+spring.application.name=devhub
+spring.data.mongodb.uri=${MONGOURI}
+jwt.secret=${JWT_SECRET}
+spring.data.mongodb.database=DevHubDB
+logging.level.org.springframework.data.mongodb=DEBUG


### PR DESCRIPTION
Se relizo el refacto del login de usuario para soportar tokens JWT. Para ello se crearon diferentes clases de configuracion y se modifico el endpoint que existia.